### PR TITLE
✨ feat: rebrand Portkey to FairyVault on download page

### DIFF
--- a/src/constants/downloadPageData.ts
+++ b/src/constants/downloadPageData.ts
@@ -16,34 +16,34 @@ export interface IDownloadPageData {
 }
 
 export const downloadPageData: IDownloadPageData = {
-  metaTitle: 'Portkey Download',
+  metaTitle: 'FairyVault Download',
   tabs: [
     {
       name: 'Chrome',
       type: DEVICE_TYPE.WebChrome,
       selected: true,
-      title: 'Portkey DID for Chrome browser',
-      content: 'Portkey DID Extension is a safe and user-friendly entrance to Web3 for everyone',
+      title: 'FairyVault for Chrome browser',
+      content: 'FairyVault Extension is a safe and user-friendly entrance to Web3 for everyone',
       tip: 'Download the extension from the official website and check its SSL certification',
-      tipLink: 'https://portkey.finance/',
+      tipLink: 'https://fairyvault.com/',
     },
     {
       name: 'Android',
       type: DEVICE_TYPE.Android,
       selected: false,
-      title: 'Portkey DID for Android',
-      content: 'Portkey DID is a safe and user-friendly entrance to Web3 for everyone',
+      title: 'FairyVault for Android',
+      content: 'FairyVault is a safe and user-friendly entrance to Web3 for everyone',
       tip: 'Download the app from the official website and check its SSL certification',
-      tipLink: 'https://portkey.finance/',
+      tipLink: 'https://fairyvault.com/',
     },
     {
       name: 'iOS',
       type: DEVICE_TYPE.IOS,
       selected: false,
-      title: 'Portkey DID for iOS',
-      content: 'Portkey DID is a safe and user-friendly entrance to Web3 for everyone',
+      title: 'FairyVault for iOS',
+      content: 'FairyVault is a safe and user-friendly entrance to Web3 for everyone',
       tip: 'Download the app from the official website and check its SSL certification',
-      tipLink: 'https://portkey.finance/',
+      tipLink: 'https://fairyvault.com/',
     },
   ],
 };

--- a/src/page-components/DownloadGroupForDownloadPage/index.tsx
+++ b/src/page-components/DownloadGroupForDownloadPage/index.tsx
@@ -21,7 +21,7 @@ function IOSButtonGroup({ storeUrl, qrCodeImg }: { storeUrl: string; qrCodeImg: 
   return (
     <>
       <IOSDownloadButton storeUrl={storeUrl} />
-      <QRCodeDownloadButton qrCodeImg={s3Url + qrCodeImg} />
+      {qrCodeImg && <QRCodeDownloadButton qrCodeImg={s3Url + qrCodeImg} />}
     </>
   );
 }
@@ -40,9 +40,9 @@ function AndroidButtonGroup({
       <div className={styles.btnGroup}>
         <AndroidDownloadButton storeUrl={googlePlayUrl} />
         <div className={styles.gap} />
-        <ApkDownloadButton apkS3Url={apkS3Url} />
+        {apkS3Url && <ApkDownloadButton apkS3Url={apkS3Url} />}
       </div>
-      <QRCodeDownloadButton qrCodeImg={s3Url + qrCodeImg} />
+      {qrCodeImg && <QRCodeDownloadButton qrCodeImg={s3Url + qrCodeImg} />}
     </div>
   );
 }

--- a/src/page-components/NavFooter/index.tsx
+++ b/src/page-components/NavFooter/index.tsx
@@ -124,7 +124,7 @@ export default function NavFooter({
               );
             })}
           </div>
-          <div className={clsx(styles.footerPortKey, footerPortKeyClassName)}>Portkey@{getFullYear()}</div>
+          <div className={clsx(styles.footerPortKey, footerPortKeyClassName)}>FairyVault@{getFullYear()}</div>
         </div>
       </div>
     </footer>

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -103,7 +103,12 @@ export default function Download({ headerNav, footerNav, socialMedia, downloadRe
                 <DownloadGroupForDownloadPage
                   className={styles.downloadBtn}
                   type={tabChangeUaType}
-                  resource={downloadResource || {}}
+                  resource={{
+                    iosDownloadUrl: 'https://apps.apple.com/us/app/fairyvault/id6741625830',
+                    androidDownloadUrl: 'https://play.google.com/store/apps/details?id=com.portkey.fairyvault',
+                    extensionDownloadUrl:
+                      'https://chromewebstore.google.com/detail/fairy-vault/jhgjbdpoodaokoflbmdmlllgehdhkmja',
+                  }}
                 />
               </motion.div>
               {/* In the webpage, SSL_Tip content appears on the left */}
@@ -113,14 +118,14 @@ export default function Download({ headerNav, footerNav, socialMedia, downloadRe
             </div>
             <div className={clsx(['flex-column-center', styles.pageRight])}>
               <motion.div variants={variantDownToUp(2)}>
-                <CommonImage
+                {/* <CommonImage
                   src={rightImage}
                   width={600}
                   height={600}
                   className={styles.mainImage}
                   layout="intrinsic"
                   priority
-                />
+                /> */}
               </motion.div>
             </div>
           </div>


### PR DESCRIPTION
## Changes
- Update brand name from Portkey to FairyVault in download page data
- Update official website links to fairyvault.com
- Add conditional rendering for QRCode and APK download buttons
- Update footer copyright to FairyVault
- Update download URLs for iOS, Android and Chrome extension